### PR TITLE
Add CHIP-8 test suite to the list of testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To add something to this list, please see the [contribution guidelines](CONTRIBU
 ### Testing
 
 * [chip8-test-rom](https://github.com/corax89/chip8-test-rom) - corax89's CHIP-8 test program, which tests most instructions for correct (Super-CHIP compliant) behavior.
+* [CHIP-8 test suite](https://github.com/Timendus/chip8-test-suite) - Timendus' collection of tests, including an improved version of corax89's test rom, a test for the behaviour of the flags and a CHIP-8 / Super-CHIP / XO-CHIP quirks test.
 * [Delay timer test](https://github.com/mattmikolay/chip-8/tree/master/delaytimer) - Test program that checks the delay timer's behavior.
 * [Random number test](https://github.com/mattmikolay/chip-8/tree/master/randomnumber) - Test program that checks the spread and mask for random number generation.
 


### PR DESCRIPTION
My "test suite" seems to be helping a lot of people who stumble upon it. So I figured it would be a shame not to mention it in this excellent list :) I was a bit unsure about where in the list to put it, hope this is the most logical order.